### PR TITLE
feat: record upload target node DID

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ We collect information about the data sources created, the shards that are trans
     * ID (shard CID)
     * Source ID
     * Size
+    * Target node DID
     * Location commitment CID
     * Location commitment URL
     * Error details

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,7 @@ while (totalSize < maxBytes) {
               await shardLog.append({
                 id: cid.toString(),
                 source: source.id,
+                node: site ? site.issuer.did() : '',
                 locationCommitment: site ? site.cid.toString() : '',
                 url,
                 size: car.size,


### PR DESCRIPTION
The location commitment issuer is the upload target.

Note: if an error occurs this will be blank. Would need to make some changes to the JS upload client in order to expose allocation receipt for us to be able to get the DID in this case...