### PR TITLE
feat: record entire upload time

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ We collect information about the data sources created, the shards that are trans
     * Location commitment CID
     * Location commitment URL
     * Error details
-    * Created at
-    * Transferred at
+    * Transfer started at
+    * Transfer ended at
 * Upload
     * ID (DAG root CID)
     * Source ID
     * Shard CIDs
-    * Created at
+    * Upload started at
+    * Upload ended at (including all shards, index and `upload/add` registration)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "upload-tester",
+      "name": "network-tester",
       "version": "1.0.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -17,6 +17,7 @@
         "bytes": "^3.1.2",
         "carstream": "^2.3.0",
         "dotenv": "^17.2.0",
+        "humanize-duration": "^3.33.0",
         "multiformats": "^13.3.7",
         "random-bytes-readable-stream": "^3.0.0",
         "random-word": "^3.0.0",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@types/bytes": "^3.1.5",
+        "@types/humanize-duration": "^3.27.4",
         "@types/node": "^24.0.12",
         "@types/random-word": "^2.0.2"
       }
@@ -415,6 +417,13 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.5.tgz",
       "integrity": "sha512-VgZkrJckypj85YxEsEavcMmmSOIzkUHqWmM4CCyia5dc54YwsXzJ5uT4fYxBQNEXx+oF1krlhgCbvfubXqZYsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/humanize-duration": {
+      "version": "3.27.4",
+      "resolved": "https://registry.npmjs.org/@types/humanize-duration/-/humanize-duration-3.27.4.tgz",
+      "integrity": "sha512-yaf7kan2Sq0goxpbcwTQ+8E9RP6HutFBPv74T/IA/ojcHKhuKVlk2YFYyHhWZeLvZPzzLE3aatuQB4h0iqyyUA==",
       "dev": true,
       "license": "MIT"
     },
@@ -852,6 +861,12 @@
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
       "license": "MIT"
+    },
+    "node_modules/humanize-duration": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.33.0.tgz",
+      "integrity": "sha512-vYJX7BSzn7EQ4SaP2lPYVy+icHDppB6k7myNeI3wrSRfwMS5+BHyGgzpHR0ptqJ2AQ6UuIKrclSg5ve6Ci4IAQ==",
+      "license": "Unlicense"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bytes": "^3.1.2",
     "carstream": "^2.3.0",
     "dotenv": "^17.2.0",
+    "humanize-duration": "^3.33.0",
     "multiformats": "^13.3.7",
     "random-bytes-readable-stream": "^3.0.0",
     "random-word": "^3.0.0",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@types/bytes": "^3.1.5",
+    "@types/humanize-duration": "^3.27.4",
     "@types/node": "^24.0.12",
     "@types/random-word": "^2.0.2"
   }


### PR DESCRIPTION
Record the entire upload time as well as the upload time for individual shards.

Minor refactor to rename shard `created`/`transferred` to `started`/`ended` - more appropriate naming since we always record end time even if the stard does not fully transfer.