### PR TITLE
chore: add config for the hot staging network

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -3,5 +3,5 @@ PRIVATE_KEY=
 PROOF=
 # Optional - any string to describe geographic region where test is being run
 REGION=
-# Optional - the network to test (hot/staging-warm/...), defaults to "hot".
+# Optional - the network to test (hot/staging-warm/staging/...), defaults to "hot".
 NETWORK=

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,12 @@ const stagingWarmConnection = Service.uploadServiceConnection({
   headers
 })
 
+const stagingConnection = Service.uploadServiceConnection({
+  id: DID.parse('did:web:staging.up.storacha.network'),
+  url: new URL('https://staging.up.storacha.network'),
+  headers
+})
+
 const hotConnection = Service.uploadServiceConnection({
   id: DID.parse('did:web:up.storacha.network'),
   url: new URL('https://up.storacha.network'),
@@ -45,7 +51,9 @@ const hotConnection = Service.uploadServiceConnection({
 
 export const connection = process.env.NETWORK === 'staging-warm'
   ? stagingWarmConnection
-  : hotConnection
+  : process.env.NETWORK === 'staging'
+    ? stagingConnection
+    : hotConnection
 
 export const id = Ed25519.parse(process.env.PRIVATE_KEY ?? '')
 


### PR DESCRIPTION
there were settings for hot production and warm staging. Adding hot staging so that tests can target that network too.