### PR TITLE
feat: use env file in Go tests and add config for hot staging network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+ifneq (,$(wildcard ./.env))
+	include .env
+	export
+else
+	$(error You haven't setup your .env file. Please copy .env.tpl to .env and fill in the values.)
+endif
+
+.PHONY: test-retrieval
+test-retrieval:
+	go test -v ./... -run ^TestRetrieval$

--- a/config.go
+++ b/config.go
@@ -4,16 +4,28 @@ import (
 	"net/url"
 	"os"
 
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/storacha/go-ucanto/did"
 )
 
-var IndexingServicePrincipal = Must(did.Parse("did:web:indexer.storacha.network"))
-var IndexingServiceURL = Deref(Must(url.Parse("https://indexer.storacha.network")))
+var log = logging.Logger("network-tester")
+
+var IndexingServicePrincipal did.DID
+var IndexingServiceURL url.URL
 
 func init() {
-	if os.Getenv("NETWORK") == "staging-warm" {
-		IndexingServicePrincipal = Must(did.Parse("did:web:indexer.warm.storacha.network"))
-		IndexingServiceURL = Deref(Must(url.Parse("https://indexer.warm.storacha.network")))
+	switch os.Getenv("NETWORK") {
+	case "", "hot":
+		IndexingServicePrincipal = Must(did.Parse("did:web:indexer.storacha.network"))
+		IndexingServiceURL = Deref(Must(url.Parse("https://indexer.storacha.network")))
+	case "staging":
+		IndexingServicePrincipal = Must(did.Parse("did:web:staging.indexer.storacha.network"))
+		IndexingServiceURL = Deref(Must(url.Parse("https://staging.indexer.storacha.network")))
+	case "staging-warm":
+		IndexingServicePrincipal = Must(did.Parse("did:web:staging.indexer.warm.storacha.network"))
+		IndexingServiceURL = Deref(Must(url.Parse("https://staging.indexer.warm.storacha.network")))
+	default:
+		panic("unknown network: " + os.Getenv("NETWORK"))
 	}
 }
 


### PR DESCRIPTION
added a Makefile so that Go tests also use the vars in `.env`.