### PR TITLE
fix: query the indexing-service to fetch location commitments for each shard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ endif
 
 .PHONY: test-retrieval
 test-retrieval:
-	go test -v ./... -run ^TestRetrieval$
+	go test -v ./... -timeout 30m -run ^TestRetrieval$


### PR DESCRIPTION
The test was expecting to find location commitments for all shards in a multi-shard upload in the result of the root query to the indexing-service.

However, that is not how the indexing-service works. It will only include the location commitment of the shard that contains the root and the index. To retrieve location commitments for other shards in the index, a new query to the indexing-service is necessary.

Additionally, the timeout for the test is bumped to 30 min from the default 10 min. It can get some time to run if the claims are not cached.