### PR TITLE
feat: add forge-prod settings

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -3,7 +3,7 @@ PRIVATE_KEY=
 PROOF=
 # Optional - any string to describe geographic region where test is being run
 REGION=
-# Optional - the network to test (hot/staging-warm/staging/...), defaults to "hot".
+# Optional - the network to test (hot/staging/staging-warm/forge-prod...), defaults to "hot".
 NETWORK=
 
 # Upload Test Overrides

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ func init() {
 
 func Load() {
 	switch os.Getenv("NETWORK") {
-	case "", "hot":
+	case "", "hot", "prod":
 		IndexingServicePrincipal = Must(did.Parse("did:web:indexer.storacha.network"))
 		IndexingServiceURL = Must(url.Parse("https://indexer.storacha.network"))
 		UploadServicePrincipal = Must(did.Parse("did:web:up.storacha.network"))
@@ -50,6 +50,12 @@ func Load() {
 		UploadServicePrincipal = Must(did.Parse("did:web:staging.up.warm.storacha.network"))
 		UploadServiceURL = Must(url.Parse("https://staging.up.warm.storacha.network"))
 		Replicas = 3
+	case "forge-prod":
+		IndexingServicePrincipal = Must(did.Parse("did:web:indexer.forge.storacha.network"))
+		IndexingServiceURL = Must(url.Parse("https://indexer.forge.storacha.network"))
+		UploadServicePrincipal = Must(did.Parse("did:web:up.forge.storacha.network"))
+		UploadServiceURL = Must(url.Parse("https://up.forge.storacha.network"))
+		Replicas = 1
 	default:
 		panic("unknown network: " + os.Getenv("NETWORK"))
 	}


### PR DESCRIPTION
Allows using the network-tester in `forge-prod`.

Beware that doing so costs money 💸, so maybe we prefer not to merge this.